### PR TITLE
Reduce bundle size

### DIFF
--- a/src/components/save-combo-button/index.tsx
+++ b/src/components/save-combo-button/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { faker } from '@faker-js/faker'
 
 import { useComboStore } from '@/stores/combo-store'
 import { useSoundsStateStore } from '@/stores/sounds-state-store'
@@ -8,6 +7,7 @@ import { useThemeStore } from '@/stores/theme-store'
 import { actionButton } from '@/shared/styles/action-button'
 import { input } from './styles'
 import { FiCheck } from 'react-icons/fi'
+import { randomString } from '@/libs/utils'
 
 export function SaveComboButton() {
   const sounds = useSoundsStateStore(state => state.sounds)
@@ -31,7 +31,7 @@ export function SaveComboButton() {
     const activeSounds = sounds.filter(sound => sound.active)
 
     saveCombo({
-      id: faker.string.alphanumeric({ casing: 'lower', length: 6 }),
+      id: randomString(6),
       name: comboName,
       sounds: activeSounds,
       theme

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,0 +1,5 @@
+export function randomString(length: number): string {
+  return Math.random()
+    .toString(36)
+    .substring(2, length + 2)
+}


### PR DESCRIPTION
Reduce bundle size by replacing faker-js/alphanumeric with a Math.random() alternative. This should also improve the PageSpeed score.

Before:
![before](https://github.com/mateusfg7/Noisekun/assets/20614119/c50fece5-bbb1-45f1-a0a1-f4fe0e418989)

After:
![after](https://github.com/mateusfg7/Noisekun/assets/20614119/9b6652bb-5d39-4376-9489-ce1fe62fcbe9)